### PR TITLE
MySQL Compatibility

### DIFF
--- a/djeneralize/models.py
+++ b/djeneralize/models.py
@@ -16,7 +16,7 @@
 import re
 
 from django.db.models.base import ModelBase, Model
-from django.db.models.fields import FieldDoesNotExist, TextField
+from django.db.models.fields import FieldDoesNotExist, CharField
 from django.dispatch import Signal
 
 from djeneralize import PATH_SEPERATOR
@@ -176,7 +176,7 @@ class BaseGeneralizationModel(Model):
 
     __metaclass__ = BaseGeneralizationMeta
 
-    specialization_type = TextField(db_index=True)
+    specialization_type = CharField(db_index=True, max_length=255)
     """Field to store the specialization"""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
It looks like the current field definition in Djeneralize isn't compatible with MySQL -- the TextField maps to a BLOB, which isn't indexable on MySQL. This is a change to switch the field to a CharField of the max indexable length as described here: 

http://docs.djangoproject.com/en/dev/ref/databases/
